### PR TITLE
Enhance active list

### DIFF
--- a/controllers/BusAPIController.js
+++ b/controllers/BusAPIController.js
@@ -18,7 +18,8 @@ class BusAPIController extends Controller {
 		this.get('/timings/:busStop', this.arrivalsAPI);
 		this.get('/services/active', this.activeServicesAPI);
 		this.get('/services/:service/info', this.serviceInfoAPI);
-		this.get('/services/:service/stops', this.serviceStopsAPI)
+		this.get('/services/:service/stops', this.serviceStopsAPI);
+		this.get('/services/:service/:direction/isActive', this.activeQueryAPI);
 		this.get('/services/list', this.serviceListAPI);
 	}
 
@@ -29,6 +30,20 @@ class BusAPIController extends Controller {
 	serviceListAPI(req, res) {
 		this.transitLinkModel.getAllServices(services => {
 			res.json(services);
+		});
+	}
+
+	activeQueryAPI(req, res) {
+		this.activeBusServicesModel.isServiceActive(req.params.service, req.params.direction, (isActive, asOf) => {
+			if (isActive === null) 
+				res.status(500).json({
+					error: 'Server is currently building data!'
+				});
+			else
+				res.json({
+					isActive: isActive,
+					asOf: asOf
+				});
 		});
 	}
 

--- a/models/ActiveBusServicesModel.js
+++ b/models/ActiveBusServicesModel.js
@@ -18,29 +18,55 @@ class ActiveBusServicesModel {
 		this.cacheUpdater();
 	}
 
+	isServiceActive(serviceNo, direction, callback) {
+        if (!this.cache.currentlyActiveServices) {callback(null);return}
+		for (let service of this.cache.currentlyActiveServices) {
+			if (service.serviceNo === serviceNo && service.direction.toString() === direction) {
+				callback(true, this.cache.lastRefreshTime);
+				return;
+			}
+		}
+		callback(false);
+	}
+
 	cacheUpdater() {
 		this.busServiceAPI.getBusServicesOperatingNow(services => {
-			var uniqueServices = {};
-			for (let service of services) 
-				if (!uniqueServices[service.serviceNo])
-					uniqueServices[service.serviceNo] = {dirs: [service.direction], svc: service.serviceNo};
-				else
-					uniqueServices[service.serviceNo].dirs.push(service.direction);
 			var list = {
-				currentlyActiveServices: Object.keys(uniqueServices).map(service => {
-					service = uniqueServices[service];
+				currentlyActiveServices: services.map(service => {
 					return {
-						serviceNo: `${service.svc}D{${service.dirs.reduce((a,b)=>a+','+b, '').substring(1)}}`,
+						serviceNo: service.serviceNo,
+						direction: service.direction,
 					};
-				}).filter(Boolean),
+				}),
 				lastRefreshTime: new Date()
 			};
 			this.cache = list;
-		});
+		}, 2);
 	}
 
 	getActiveBusServices(callback) {
-		callback(this.cache);
+
+		if (!this.cache.currentlyActiveServices) {callback({});return}
+		var services = this.cache.currentlyActiveServices;
+
+		var uniqueServices = {};
+		for (let service of services)
+			if (!uniqueServices[service.serviceNo])
+				uniqueServices[service.serviceNo] = {dirs: [service.direction], svc: service.serviceNo};
+			else
+				uniqueServices[service.serviceNo].dirs.push(service.direction);
+		var list = {
+			currentlyActiveServices: Object.keys(uniqueServices).map(service => {
+				service = uniqueServices[service];
+				return {
+					serviceNo: `${service.svc}D{${service.dirs.reduce((a,b)=>a+','+b, '').substring(1)}}`,
+				};
+			}).filter(Boolean),
+			lastRefreshTime: services.lastRefreshTime
+		};
+
+
+		callback(list);
 	}
 
 }

--- a/models/ActiveBusServicesModel.js
+++ b/models/ActiveBusServicesModel.js
@@ -20,13 +20,19 @@ class ActiveBusServicesModel {
 
 	cacheUpdater() {
 		this.busServiceAPI.getBusServicesOperatingNow(services => {
+			var uniqueServices = {};
+			for (let service of services) 
+				if (!uniqueServices[service.serviceNo])
+					uniqueServices[service.serviceNo] = {dirs: [service.direction], svc: service.serviceNo};
+				else
+					uniqueServices[service.serviceNo].dirs.push(service.direction);
 			var list = {
-				currentlyActiveServices: services.map(service => {
+				currentlyActiveServices: Object.keys(uniqueServices).map(service => {
+					service = uniqueServices[service];
 					return {
-						serviceNo: service.serviceNo,
-						direction: service.direction
+						serviceNo: `${service.svc}D{${service.dirs.reduce((a,b)=>a+','+b, '').substring(1)}}`,
 					};
-				}),
+				}).filter(Boolean),
 				lastRefreshTime: new Date()
 			};
 			this.cache = list;

--- a/models/BusAPIListModel.js
+++ b/models/BusAPIListModel.js
@@ -14,14 +14,16 @@ class BusAPIListModel extends Model {
 				'active-services': 'Provides info on currently running bus services.',
 				'service-info': 'Provides basic info about a bus service.',
 				'service-stops': 'Provides the list of bus stops for a service',
-				'service-list': 'Lists all bus services in Singapore'
+				'service-list': 'Lists all bus services in Singapore',
+				'is-active': 'Queries if a bus service is active'
 			},
 			paths: {
 				timings: '/bus/timings/:busStop',
 				'active-services': '/bus/services/active',
 				'service-info': '/bus/services/:service/info',
 				'service-stops': '/bus/services/:service/stops',
-				'service-list': '/bus/services/list'
+				'service-list': '/bus/services/list',
+				'is-active': '/bus/services/:service/:direction/isActive'
 			}
 		});
 	}


### PR DESCRIPTION
This wil fix issue #4. Now, requests to `/bus/services/active/` will be shorter by around 50%. Also, there is now a query system on `/bus/services/:service/:direction/isActive` to directly query if a service is active.